### PR TITLE
Pass timezone options to mysql2 gem

### DIFF
--- a/lib/em-sequel-async/mysql.rb
+++ b/lib/em-sequel-async/mysql.rb
@@ -26,6 +26,7 @@ class EmSequelAsync::Mysql
     # == Instance Methods ===================================================
     
     def initialize(db)
+      @db = db
       @options = {
         :symbolize_keys => true,
         :cast_booleans => true
@@ -105,7 +106,7 @@ class EmSequelAsync::Mysql
       @connections[connection] = [ query, callback ]
 
       start = Time.now
-      deferrable = connection.query(query)
+      deferrable = connection.query(query, :database_timezone => @db.timezone, :application_timezone => Sequel.application_timezone)
       
       deferrable.callback do |result|
         log(:debug, "(%.6fs) [OK] %s" % [ Time.now - start, query ])


### PR DESCRIPTION
With this patch, em-sequel-async will pass [timezone settings](http://sequel.jeremyevans.net/rdoc/classes/Sequel/Timezones.html) to mysql2 gem, like the official (non-EM) mysql2 adapter do: https://github.com/jeremyevans/sequel/blob/90faf821788ffbbda90bc06d3ad76d0113556bb9/lib/sequel/adapters/mysql2.rb#L80

Thank you for your gem by the way :-)
